### PR TITLE
Better tests, configurable and again simplified dot file

### DIFF
--- a/thirsty.sh
+++ b/thirsty.sh
@@ -9,7 +9,8 @@ drink_water() {
     date +%s > $DRINK_WATER_CONF
   fi
 
-  next_time=$(($(cat $DRINK_WATER_CONF) + $WATER_TIME))
+  # Tail is used to remain compatible with the pervious file format
+  next_time=$(($(tail -1 $DRINK_WATER_CONF) + $WATER_TIME))
 
   if [ $next_time -lt $(date +%s) ]; then
     echo -n "💧 You're thirsty"

--- a/thirsty.sh
+++ b/thirsty.sh
@@ -1,39 +1,27 @@
 #!/bin/sh
 
 WATER_TIME=${WATER_TIME:-10800} # Set time interval in seconds
-DRINK_WATER_CONF="$HOME/.water"
+DRINK_WATER_CONF="${DRINK_WATER_CONF:-$HOME/.water}"
 
 drink_water() {
   # If the file doesn't exist, create it
   if [ ! -f $DRINK_WATER_CONF ]; then
-    not_thirsty
+    date +%s > $DRINK_WATER_CONF
   fi
 
-  thirsty=$(head -1 $DRINK_WATER_CONF)
-  last_time=$(tail -1 $DRINK_WATER_CONF)
+  next_time=$(($(cat $DRINK_WATER_CONF) + $WATER_TIME))
 
-  if [ $thirsty = 'false' ]; then
-    echo "true" > $DRINK_WATER_CONF
-    echo "$(($(date +%s) + $WATER_TIME))" >> $DRINK_WATER_CONF
-    echo -n "Water is essential "
-  elif [ $last_time -lt $(date +%s) ]; then
+  if [ $next_time -lt $(date +%s) ]; then
     echo -n "💧 You're thirsty"
   fi
 }
 
 not_thirsty() {
-  echo "false" > $DRINK_WATER_CONF
-  echo "0" >> $DRINK_WATER_CONF
+  date +%s > $DRINK_WATER_CONF
+  echo "Water is essential"
 }
 
-# Username.
-# If user is root, then print it in red. Otherwise, just print in yellow.
-spaceship_user() {
-  if [ $USER = 'root' ]; then
-    echo -n "%{$fg_bold[red]%}"
-  else
-    echo -n "%{$fg_bold[yellow]%}"
-  fi
-  echo -n "%n"
-  echo -n "%{$reset_color%}"
+next_drink() {
+  next_time=$(($(cat $DRINK_WATER_CONF) + $WATER_TIME))
+  echo "Next drink at $(date --date="@$next_time")"
 }

--- a/thirsty_test.sh
+++ b/thirsty_test.sh
@@ -2,16 +2,51 @@
 
 # Override default water time
 WATER_TIME=5
+DRINK_WATER_CONF=$PWD/test.water
+
+rm -f $DRINK_WATER_CONF
 
 . ./thirsty.sh
 
-echo "Water time: $WATER_TIME"
+echo "Running tests..."
 
-drink_water
-echo
-not_thirsty
-drink_water
-echo
+# Test that drink_water returns nothing
+out="$(drink_water)"
+if [ -n "$out" ]; then
+    echo "drink_water error. Expected '', got '$out'"
+    exit 1
+fi
+
 sleep $(($WATER_TIME + 1))
-drink_water
-echo
+
+# Test that drink_water tells us it's time for a drink
+out="$(drink_water)"
+expected="💧 You're thirsty"
+if [ "$out" != "$expected" ]; then
+    echo "drink_water error. Expected '$expected', got '$out'"
+    exit 1
+fi
+
+# Test that not_thirsty sets a new time
+before="$(cat $DRINK_WATER_CONF)"
+out="$(not_thirsty)"
+expected="Water is essential"
+if [ "$out" != "$expected" ]; then
+    echo "not_thirsty error. Expected '$expected', got '$out'"
+    exit 1
+fi
+if [ "$before" = "$(cat $DRINK_WATER_CONF)" ]; then
+    echo "not_thirsty error. Last drink time was not updated"
+    exit 1
+fi
+
+# Test that next_drink outputs correctly
+out="$(next_drink)"
+expected="Next drink at $(date --date="@$(($(cat $DRINK_WATER_CONF) + $WATER_TIME))")"
+if [ "$out" != "$expected" ]; then
+    echo "next_drink error. Expected '$expected', got '$out'"
+    exit 1
+fi
+
+rm -f $DRINK_WATER_CONF
+echo "All tests passed"


### PR DESCRIPTION
The dot file now contains the last time not_thirsty was called. The next drink time is calculated each prompt to account for changes in WATER_TIME. This way if someone wants to adjust the time, they don't have to reset the time completely. Tail is still used to get the time so existing files will work and will be converted to the time-only format the next time the user runs not_thirsty.

The tests have been rewritten to be actual tests. They check the output of the commands at every stage to ensure proper output. It will exit with error code 1 if something fails.

Added a new command `next_drink` which simply outputs the time of the next drink.