### PR TITLE
Changing options used in the date function

### DIFF
--- a/thirsty.sh
+++ b/thirsty.sh
@@ -24,5 +24,5 @@ not_thirsty() {
 
 next_drink() {
   next_time=$(($(cat $DRINK_WATER_CONF) + $WATER_TIME))
-  echo "Next drink at $(date --date="@$next_time")"
+  echo "Next drink at $(date -r $next_time)"
 }


### PR DESCRIPTION
This fixes an error seen when running the `next_drink` function relating to improper usage of the `date` function.

Documented in [this issue](https://github.com/lakshaykalbhor/thirsty/issues/7).