### PR TITLE
Fix next_drink to work on *nix and Mac

### DIFF
--- a/thirsty.sh
+++ b/thirsty.sh
@@ -24,5 +24,16 @@ not_thirsty() {
 
 next_drink() {
   next_time=$(($(cat $DRINK_WATER_CONF) + $WATER_TIME))
-  echo "Next drink at $(date -r $next_time)"
+  next_date=""
+  # Mac's date command uses a different flag
+  case "$(uname)" in
+    'Darwin')
+      next_date="$(date -r $next_time)"
+      ;;
+    *)
+      next_date="$(date --date="@$next_time")"
+      ;;
+  esac
+
+  echo "Next drink at $next_date"
 }


### PR DESCRIPTION
The version merged a few days ago only works on MacOS. Mac's date uses different flags from coreutils' date command. Added a case statement to determine which OS and use the appropriate date form.